### PR TITLE
fix error of parameter initialization for LoRA embedding

### DIFF
--- a/loralib/layers.py
+++ b/loralib/layers.py
@@ -56,8 +56,8 @@ class Embedding(nn.Embedding, LoRALayer):
         nn.Embedding.reset_parameters(self)
         if hasattr(self, 'lora_A'):
             # initialize A the same way as the default for nn.Linear and B to zero
-            nn.init.zeros_(self.lora_A)
-            nn.init.normal_(self.lora_B)
+            nn.init.normal_(self.lora_A)
+            nn.init.zeros_(self.lora_B)
 
     def train(self, mode: bool = True):
         nn.Embedding.train(self, mode)


### PR DESCRIPTION
I found that the parameter initialization at **reset_parameters()** of the **Embedding** class differs from the LoRa paper and other implementations at **layers.py**. I initialized lora_A with **nn.init.normal_()** while Lora_B with  **nn.init.zeros_()**. Thanks.