### PR TITLE
Remove redundant initialization of Conv1D c_attn

### DIFF
--- a/examples/NLG/src/model.py
+++ b/examples/NLG/src/model.py
@@ -91,7 +91,6 @@ class Attention(nn.Module):
         self.n_head = config.n_head
         self.split_size = n_state
         self.scale = scale
-        self.c_attn = Conv1D(n_state * 3, nx)
         self.c_attn = lora.MergedLinear(
             nx, n_state * 3, 
             r=config.lora_attn_dim, 


### PR DESCRIPTION
This layer is immediately overwritten by the LoRA linear layer, so we don't need to initialize it in the first place. 