### PR TITLE
Enable syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ There are several directories in this repo:
 ## Quickstart
 
  1. Installing `loralib` is simply
- ```
+ ```bash
  pip install loralib
  # Alternatively
  # pip install git+https://github.com/microsoft/LoRA
  ```
 
  2. You can choose to adapt some layers by replacing them with counterparts implemented in `loralib`. We only support `nn.Linear`, `nn.Embedding`, and `nn.Conv2d` for now. We also support a `MergedLinear` for cases where a single `nn.Linear` represents more than one layers, such as in some implementations of the attention `qkv` projection (see Additional Notes for more).
- ```
+ ```python
  # ===== Before =====
  # layer = nn.Linear(in_features, out_features)
 
@@ -89,7 +89,7 @@ There are several directories in this repo:
  ```
 
  3. Before the training loop begins, mark only LoRA parameters as trainable.
- ```
+ ```python
  import loralib as lora
  model = BigModel()
  # This sets requires_grad to False for all parameters without the string "lora_" in their names
@@ -99,14 +99,14 @@ There are several directories in this repo:
     ...
  ```
  4. When saving a checkpoint, generate a `state_dict` that only contains LoRA parameters.
- ```
+ ```python
  # ===== Before =====
  # torch.save(model.state_dict(), checkpoint_path)
  # ===== After =====
  torch.save(lora.lora_state_dict(model), checkpoint_path)
  ```
  5. When loading a checkpoint using `load_state_dict`, be sure to set `strict=False`.
- ```
+ ```python
  # Load the pretrained checkpoint first
  model.load_state_dict(torch.load('ckpt_pretrained.pt'), strict=False)
  # Then load the LoRA checkpoint
@@ -120,7 +120,7 @@ There are several directories in this repo:
 1. While we focus on a simple yet effect setup, namely adapting only the `q` and `v` projection in a Transformer, in our examples, LoRA can be apply to any subsets of pre-trained weights. We encourage you to explore different configurations, such as adapting the embedding layer by replacing `nn.Embedding` with `lora.Embedding` and/or adapting the MLP layers. It's very likely that the optimal configuration varies for different model architectures and tasks.
 
 2. Some Transformer implementation uses a single `nn.Linear` for the projection matrices for query, key, and value. If one wishes to constrain the rank of the updates to the individual matrices, one has to either break it up into three separate matrices or use `lora.MergedLinear`. Make sure to modify the checkpoint accordingly if you choose to break up the layer.
-```
+```python
 # ===== Before =====
 # qkv_proj = nn.Linear(d_model, 3*d_model)
 # ===== After =====
@@ -132,7 +132,7 @@ v_proj = lora.Linear(d_model, d_model, r=8)
 qkv_proj = lora.MergedLinear(d_model, 3*d_model, r=8, enable_lora=[True, False, True])
 ```
 3. Training bias vectors in tandem with LoRA might be a cost-efficient way to squeeze out extra task performance (if you tune the learning rate carefully). While we did not study its effect thoroughly in our paper, we make it easy to try in `lora`. You can mark some biases as trainable by passing "all" or "lora_only" to `bias=` when calling `mark_only_lora_as_trainable`. Remember to pass the corresponding `bias=` argument to `lora_state_dict` when saving a checkpoint.
-```
+```python
 # ===== Before =====
 # lora.mark_only_lora_as_trainable(model) # Not training any bias vectors
 # ===== After =====
@@ -164,7 +164,7 @@ The RoBERTa/DeBERTa example:
 We thank in alphabetical order Jianfeng Gao, Jade Huang, Jiayuan Huang, Lisa Xiang Li, Xiaodong Liu, Yabin Liu, Benjamin Van Durme, Luis Vargas, Haoran Wei, Peter Welinder, and Greg Yang for providing valuable feedback.
 
 ## Citation
-```
+```BibTeX
 @misc{hu2021lora,
     title={LoRA: Low-Rank Adaptation of Large Language Models},
     author={Hu, Edward and Shen, Yelong and Wallis, Phil and Allen-Zhu, Zeyuan and Li, Yuanzhi and Wang, Lu and Chen, Weizhu},


### PR DESCRIPTION
This enables GitHub's syntax highlighting in Markdown files by specifying the languages used. It makes the code easier to read.