### PR TITLE
fix syntax error from indentation

### DIFF
--- a/loralib/layers.py
+++ b/loralib/layers.py
@@ -82,7 +82,7 @@ class Embedding(nn.Embedding, LoRALayer):
                 self.norm_type, self.scale_grad_by_freq, self.sparse
             )
             result += (after_A @ self.lora_B.transpose(0, 1)) * self.scaling
-        return result
+            return result
         else:
             return nn.Embedding.forward(self, x)
             


### PR DESCRIPTION
File `layers.py` contains a minor syntax error preventing it from being usable.

The error was introduced a couple of hours ago by 
https://github.com/microsoft/LoRA/commit/2e08c961e1f347f7c74de4c575c22ec4c3a0c4b3