### PR TITLE
Fix the requires_grad adjustment logic in mark_only_lora_as_trainable

### DIFF
--- a/loralib/utils.py
+++ b/loralib/utils.py
@@ -14,6 +14,8 @@ def mark_only_lora_as_trainable(model: nn.Module, bias: str = 'none') -> None:
     for n, p in model.named_parameters():
         if 'lora_' not in n:
             p.requires_grad = False
+        else:
+            p.requires_grad = True
     if bias == 'none':
         return
     elif bias == 'all':


### PR DESCRIPTION
Added code to the `mark_only_lora_as_trainable` method to set `requires_grad` to True for parameters with `lora_` in the name.

This change was made for the following reason.

Sometimes `requires_grad` may be set to False for all parameters of the whole model before calling the `mark_only_lora_as_trainable` method, and if following the logic of the existing `mark_only_lora_as_trainable` method, the `requires_grad` of the parameter whose name contains `lora_` is still set to False after calling, which I think has some conflict with the method name `mark_only_lora_as_trainable`.