### PR TITLE
improve mark_only_lora_as_trainable

### DIFF
--- a/loralib/utils.py
+++ b/loralib/utils.py
@@ -11,9 +11,11 @@ from .layers import LoRALayer
 
 
 def mark_only_lora_as_trainable(model: nn.Module, bias: str = 'none') -> None:
-    for n, p in model.named_parameters():
-        if 'lora_' not in n:
-            p.requires_grad = False
+    for n, p in model.named_modules():
+        if not isinstance(p, LoRALayer):
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
     if bias == 'none':
         return
     elif bias == 'all':


### PR DESCRIPTION
It doesn't follow OOP principle to check layers by name instead of type by inheritence. Also naming is in quite convenient, e.g. when I just want to name the module self.query instead of self.lora_query so that I can load the original weights. 
Also changed it to set lora layers requires_grad=True, as the function name suggests (requires_grad can default to false).