### PR TITLE
Initialization for LoRa weights A and B initialized in the wrong way.

### DIFF
--- a/loralib/layers.py
+++ b/loralib/layers.py
@@ -56,8 +56,8 @@ class Embedding(nn.Embedding, LoRALayer):
         nn.Embedding.reset_parameters(self)
         if hasattr(self, 'lora_A'):
             # initialize A the same way as the default for nn.Linear and B to zero
-            nn.init.zeros_(self.lora_A)
-            nn.init.normal_(self.lora_B)
+            nn.init.normal_(self.lora_A)
+            nn.init.zeros_(self.lora_B)
 
     def train(self, mode: bool = True):
         nn.Embedding.train(self, mode)


### PR DESCRIPTION
```python

    def reset_parameters(self):
        nn.Embedding.reset_parameters(self)
        if hasattr(self, 'lora_A'):
            # initialize A the same way as the default for nn.Linear and B to zero
            # lora_A should be normal and lora_B should be zeros
            nn.init.zeros_(self.lora_A)
            nn.init.normal_(self.lora_B)
```