### PR TITLE
Fix Conv1d (Convnd) implementation

### DIFF
--- a/loralib/layers.py
+++ b/loralib/layers.py
@@ -255,7 +255,7 @@ class ConvLoRA(nn.Module, LoRALayer):
                 self.conv.weight.new_zeros((r * kernel_size, in_channels * kernel_size))
             )
             self.lora_B = nn.Parameter(
-              self.conv.weight.new_zeros((out_channels//self.conv.groups*kernel_size, r*kernel_size))
+              self.conv.weight.new_zeros((out_channels//self.conv.groups*kernel_size**(self.conv.weight.dim()-3), r*kernel_size))
             )
             self.scaling = self.lora_alpha / self.r
             # Freezing the pre-trained weight matrix


### PR DESCRIPTION
The current Conv1d (and Conv3d) is not working due to the incompatible shape of (lora_A @ lora_B). I changed only the lora_B's initialization. The shape of lora_B now depends on the dimensions of conv.weight, so it works for 1d to n-d case. 

**Before**
```python
self.lora_B = nn.Parameter(
              self.conv.weight.new_zeros((out_channels//self.conv.groups*kernel_size, r*kernel_size))
            )
```

**After**
```python
self.lora_B = nn.Parameter(
              self.conv.weight.new_zeros((out_channels//self.conv.groups*kernel_size**(self.conv.weight.dim()-3), r*kernel_size))
            )
```

Fixes #115 