### PR TITLE
Avoid use of lambdas so that LoRA layers are pickleable.

### DIFF
--- a/loralib/layers.py
+++ b/loralib/layers.py
@@ -23,7 +23,7 @@ class LoRALayer():
         if lora_dropout > 0.:
             self.lora_dropout = nn.Dropout(p=lora_dropout)
         else:
-            self.lora_dropout = lambda x: x
+            self.lora_dropout = nn.Identity()
         # Mark the weight as unmerged
         self.merged = False
         self.merge_weights = merge_weights


### PR DESCRIPTION
LoRA layers are currently not pickleable due to the use of a lambda function. This matters because it breaks certain [DDP](https://docs.pytorch.org/tutorials/beginner/ddp_series_multigpu.html) configurations when training with Torch, given that they use pickle to pass a model between training processes.

I resolved this by replacing the lambda function with `nn.Identity`.